### PR TITLE
✨Fix for scss.js files

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,14 @@ module.exports = (options = {}) => ({
       { filter: /.\.(scss|sass)$/, namespace: "file" },
       async (args) => {
         const sourceFullPath = path.resolve(args.resolveDir, args.path);
+
+        // import 'file.scss' assumed .js extension
+        if(!fs.existsSync(sourceFullPath) && fs.existsSync(sourceFullPath + ".js")) {
+          return {
+            path: sourceFullPath + ".js",
+          };
+        }
+
         const sourceExt = path.extname(sourceFullPath);
         const sourceBaseName = path.basename(sourceFullPath, sourceExt);
         const sourceDir = path.dirname(sourceFullPath);


### PR DESCRIPTION
I have a project that uses the office-ui-fabric-react npm package.  

Some of the package code imports this way:
```
import 'SomeFile.scss'
```
but it's actually a .js file on disk.   

If 
```
import 'SomeFile'
```
assumes .js extension, then 'SomeFile.scss' should assume this as well and fall back.

This fix corrects this behavior.

