### PR TITLE
 Ignore absolute paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move to pnpm package manager
 - Move to [new workflow](https://thomaspoignant.medium.com/simple-git-flow-who-works-dac82430e484)
 - Update dependencies
+- Ignore paths starting with `/`

--- a/index.ts
+++ b/index.ts
@@ -139,6 +139,9 @@ function isLocalFileUrl(url: string): boolean {
   if (/^#/.test(url)) {
     return false;
   }
+  if (url.startsWith('/')) {
+    return false;
+  }
 
   return true;
 }

--- a/tests/images/example.scss
+++ b/tests/images/example.scss
@@ -20,6 +20,9 @@ body {
   &.absoluteUrl {
     background: url("https://should-be-ignored.com/image.png");
   }
+  &.absolutePath {
+    background: url("/should-be-ignored/image.png");
+  }
   &.pathToLocalSvg {
     background: url("subfolder/c_folder/d_folder/atom.svg#content"); // we ignore #content at the output path, since esbuild doesn't support it yet
   }


### PR DESCRIPTION
- Currently any path for externals which are relative to the current domain root get picked up as local relative paths and leave OS folders in the output path

- This fixes that and ignores paths that start with `/`

Please, make sure you did all these steps when submitting PR:

- [x] Update CHANGELOG.md, if needed
- [x] Update README.md, if needed
- [x] Update tests, if current tests do not cover your case
