### PR TITLE
Fix watch paths on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Fixed
+- Generate correct watch paths on Windows
 
 ## [1.0.1] - 2022-01-10
 ## Fixed

--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ import sass = require("sass");
 import tmp = require("tmp");
 import path = require("path");
 import csstree = require("css-tree");
+import url = require("url");
 
 type SassOptions = Omit<sass.Options<"sync">, "file">;
 
@@ -63,7 +64,7 @@ export = (options: Options = {}): Plugin => ({
           path: tmpFilePath,
           watchFiles: sassRenderResult.loadedUrls
             .filter((x) => x.protocol === "file:")
-            .map((x) => x.pathname),
+            .map(url.fileURLToPath),
         };
       }
     );


### PR DESCRIPTION
Per https://github.com/nodejs/node/issues/37845#issuecomment-803451705 , using `.pathname` doesn't work correctly on Windows, and the correct method is to use `fileURLToPath`.

(I have updated the CHANGELOG, but not the README since it is a minor fix.  I haven't added a test as there don't appear to be any tests that aren't integration tests - i.e., I'm not sure how you'd test this with the current test framework.)